### PR TITLE
Add deterministic conference tournament title probability calculation and output

### DIFF
--- a/Outputs/2026 Conference Tournament Championship Probabilities 20260314.csv
+++ b/Outputs/2026 Conference Tournament Championship Probabilities 20260314.csv
@@ -1,0 +1,21 @@
+Conference,Semifinal 1,Semifinal 2,Team,Current Elo (through 20260313),Tournament Win Probability,Tournament Win Probability (Pct)
+Big Ten,Wisconsin vs Michigan,Purdue vs UCLA,Wisconsin,1951.31,0.098651,9.87%
+Big Ten,Wisconsin vs Michigan,Purdue vs UCLA,Michigan,2183.3,0.611835,61.18%
+Big Ten,Wisconsin vs Michigan,Purdue vs UCLA,Purdue,1991.27,0.179039,17.90%
+Big Ten,Wisconsin vs Michigan,Purdue vs UCLA,UCLA,1940.85,0.110475,11.05%
+SEC,Vanderbilt vs Florida,Ole Miss vs Arkansas,Vanderbilt,1957.62,0.133605,13.36%
+SEC,Vanderbilt vs Florida,Ole Miss vs Arkansas,Florida,2141.66,0.554848,55.48%
+SEC,Vanderbilt vs Florida,Ole Miss vs Arkansas,Ole Miss,1739.58,0.023956,2.40%
+SEC,Vanderbilt vs Florida,Ole Miss vs Arkansas,Arkansas,1987.68,0.287592,28.76%
+American,Charlotte vs South Florida,Tulsa vs Wichita State,Charlotte,1513.88,0.03439,3.44%
+American,Charlotte vs South Florida,Tulsa vs Wichita State,South Florida,1801.87,0.493309,49.33%
+American,Charlotte vs South Florida,Tulsa vs Wichita State,Tulsa,1763.22,0.290539,29.05%
+American,Charlotte vs South Florida,Tulsa vs Wichita State,Wichita State,1708.64,0.181763,18.18%
+A10,Dayton vs Saint Louis,St. Joseph's vs VCU,Dayton,1743.13,0.210829,21.08%
+A10,Dayton vs Saint Louis,St. Joseph's vs VCU,Saint Louis,1756.58,0.237426,23.74%
+A10,Dayton vs Saint Louis,St. Joseph's vs VCU,St. Joseph's,1692.03,0.129983,13.00%
+A10,Dayton vs Saint Louis,St. Joseph's vs VCU,VCU,1829.77,0.421762,42.18%
+Ivy,Cornell vs Yale,Penn vs Harvard,Cornell,1561.64,0.152498,15.25%
+Ivy,Cornell vs Yale,Penn vs Harvard,Yale,1694.23,0.452325,45.23%
+Ivy,Cornell vs Yale,Penn vs Harvard,Penn,1544.77,0.149763,14.98%
+Ivy,Cornell vs Yale,Penn vs Harvard,Harvard,1598.66,0.245413,24.54%

--- a/conference_tournament_probs_20260314.py
+++ b/conference_tournament_probs_20260314.py
@@ -1,0 +1,218 @@
+import csv
+from pathlib import Path
+
+# Constants from elo.py
+ELO_BASE = 1500
+NEW_ELO = 985
+K_FACTOR = 47
+SEASON_CARRY = 0.64
+HOME_ADVANTAGE = 82
+GAMES_REQUIRED = 10
+
+DATA_FILE = Path('Data/20101101-20260313.csv')
+TODAY_PREDICTIONS_FILE = Path('Outputs/20260314 Game Predictions Based on Ratings through 20260313 with Spreads as of 20260314 at 0917.csv')
+OUT_FILE = Path('Outputs/2026 Conference Tournament Championship Probabilities 20260314.csv')
+
+CONFERENCE_SEMIS = {
+    'Big Ten': [('Wisconsin', 'Michigan'), ('Purdue', 'UCLA')],
+    'SEC': [('Vanderbilt', 'Florida'), ('Ole Miss', 'Arkansas')],
+    'American': [('Charlotte', 'South Florida'), ('Tulsa', 'Wichita State')],
+    'A10': [('Dayton', 'Saint Louis'), ("St. Joseph's", 'VCU')],
+    'Ivy': [('Cornell', 'Yale'), ('Penn', 'Harvard')],
+}
+
+# team -> conference lookup used for season carry reset by conference average
+CONFERENCE_LOOKUP = {}
+with open('Data/conferences.csv', newline='') as f:
+    reader = csv.reader(f)
+    for row in reader:
+        if len(row) >= 2:
+            CONFERENCE_LOOKUP[row[0]] = row[1]
+
+
+def winp(elo_spread: float) -> float:
+    if elo_spread > ELO_BASE:
+        return 1.0
+    if elo_spread < -ELO_BASE:
+        return 0.0
+    return 1 / (1 + 10 ** (-elo_spread / 400))
+
+
+def calc_mov_multiplier(elo_margin: float, mov: int) -> float:
+    a = (mov + 2.5) ** 0.7
+    b = 6 + max(0.006 * elo_margin, -5.99)
+    return a / b
+
+
+def season_reset(teams: dict[str, dict]) -> dict[str, dict]:
+    score_by_conf = {}
+    count_by_conf = {}
+
+    kept = {}
+    for team, d in teams.items():
+        if d['season_games'] < GAMES_REQUIRED:
+            continue
+        kept[team] = d
+        conf = d['conference']
+        score_by_conf[conf] = score_by_conf.get(conf, 0.0) + d['elo']
+        count_by_conf[conf] = count_by_conf.get(conf, 0) + 1
+
+    for team, d in kept.items():
+        conf_avg = score_by_conf[d['conference']] / count_by_conf[d['conference']]
+        d['elo'] = d['elo'] * SEASON_CARRY + (1 - SEASON_CARRY) * conf_avg
+        d['season_games'] = 0
+
+    return kept
+
+
+def get_team(teams: dict[str, dict], name: str) -> dict:
+    if name not in teams:
+        teams[name] = {
+            'elo': ELO_BASE,
+            'season_games': 0,
+            'conference': CONFERENCE_LOOKUP.get(name, 'Other'),
+        }
+    return teams[name]
+
+
+def build_elo_state(data_file: Path) -> dict[str, dict]:
+    teams = {}
+    season_count = 0
+    current_month = None
+
+    with open(data_file, newline='') as f:
+        reader = csv.reader(f)
+        for row in reader:
+            neutral, away, away_score, home, home_score, date = row[:6]
+            row_month = int(date[4:6])
+
+            if current_month is None:
+                current_month = row_month
+
+            if current_month in [3, 4] and row_month == 11:
+                season_count += 1
+                teams = season_reset(teams)
+
+            current_month = row_month
+
+            home_t = get_team(teams, home)
+            away_t = get_team(teams, away)
+
+            if season_count > 0:
+                if home_t['elo'] == ELO_BASE and home_t['season_games'] == 0:
+                    home_t['elo'] = NEW_ELO
+                if away_t['elo'] == ELO_BASE and away_t['season_games'] == 0:
+                    away_t['elo'] = NEW_ELO
+
+            hs, as_ = int(home_score), int(away_score)
+            if hs > as_:
+                winner, loser = home, away
+                ws, ls = hs, as_
+            else:
+                winner, loser = away, home
+                ws, ls = as_, hs
+
+            w_elo = teams[winner]['elo']
+            l_elo = teams[loser]['elo']
+
+            if neutral == '0':
+                if winner == home:
+                    w_elo += HOME_ADVANTAGE
+                else:
+                    l_elo += HOME_ADVANTAGE
+
+            elo_margin = w_elo - l_elo
+            w_winp = winp(elo_margin)
+            mov = ws - ls
+            delta = round(K_FACTOR * calc_mov_multiplier(elo_margin, mov) * (1 - w_winp), 2)
+
+            teams[winner]['elo'] = max(0, teams[winner]['elo'] + delta)
+            teams[loser]['elo'] = max(0, teams[loser]['elo'] - delta)
+            teams[winner]['season_games'] += 1
+            teams[loser]['season_games'] += 1
+
+    return teams
+
+
+def p_team_beats(teams: dict[str, dict], a: str, b: str) -> float:
+    return winp(teams[a]['elo'] - teams[b]['elo'])
+
+
+def conference_probs(teams_state: dict[str, dict], semis: list[tuple[str, str]]):
+    (a, b), (c, d) = semis
+
+    p_ab = p_team_beats(teams_state, a, b)
+    p_cd = p_team_beats(teams_state, c, d)
+
+    p = {}
+    p[a] = p_ab * (p_cd * p_team_beats(teams_state, a, c) + (1 - p_cd) * p_team_beats(teams_state, a, d))
+    p[b] = (1 - p_ab) * (p_cd * p_team_beats(teams_state, b, c) + (1 - p_cd) * p_team_beats(teams_state, b, d))
+    p[c] = p_cd * (p_ab * p_team_beats(teams_state, c, a) + (1 - p_ab) * p_team_beats(teams_state, c, b))
+    p[d] = (1 - p_cd) * (p_ab * p_team_beats(teams_state, d, a) + (1 - p_ab) * p_team_beats(teams_state, d, b))
+    return p
+
+
+def get_today_matchups() -> set[tuple[str, str]]:
+    pair_set = set()
+    with open(TODAY_PREDICTIONS_FILE, newline='') as f:
+        r = csv.DictReader(f)
+        for row in r:
+            pair_set.add((row['Away'], row['Home']))
+    return pair_set
+
+
+def main():
+    today_matchups = get_today_matchups()
+
+    # sanity-check our semifinal list against today's games file
+    for conf, semis in CONFERENCE_SEMIS.items():
+        for away, home in semis:
+            if (away, home) not in today_matchups and (home, away) not in today_matchups:
+                raise ValueError(f'{conf} semifinal not found in today output: {away} vs {home}')
+
+    elo_state = build_elo_state(DATA_FILE)
+
+    rows = []
+    for conf, semis in CONFERENCE_SEMIS.items():
+        teams = [semis[0][0], semis[0][1], semis[1][0], semis[1][1]]
+        probs = conference_probs(elo_state, semis)
+
+        for t in teams:
+            rows.append([
+                conf,
+                semis[0][0] + ' vs ' + semis[0][1],
+                semis[1][0] + ' vs ' + semis[1][1],
+                t,
+                round(elo_state[t]['elo'], 2),
+                round(probs[t], 6),
+                f"{probs[t]:.2%}",
+            ])
+
+    with open(OUT_FILE, 'w', newline='') as f:
+        w = csv.writer(f)
+        w.writerow([
+            'Conference',
+            'Semifinal 1',
+            'Semifinal 2',
+            'Team',
+            'Current Elo (through 20260313)',
+            'Tournament Win Probability',
+            'Tournament Win Probability (Pct)'
+        ])
+        w.writerows(rows)
+
+    print(f'Wrote {OUT_FILE}')
+
+    # print concise summary to terminal
+    by_conf = {}
+    for row in rows:
+        by_conf.setdefault(row[0], []).append(row)
+
+    for conf, conf_rows in by_conf.items():
+        print(f'\n{conf}')
+        for row in sorted(conf_rows, key=lambda x: x[5], reverse=True):
+            print(f"  {row[3]:<15} {row[6]:>8}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
### Motivation
- Provide deterministic championship probabilities for 4-team conference semifinals (Big Ten, SEC, American, A10, Ivy) without Monte Carlo runs. 
- Reuse the project’s Elo logic to compute pairwise win probabilities from historical game data through `20260313` so outputs match the rating state used elsewhere. 
- Validate that the configured semifinal matchups appear in today’s predictions before computing results.

### Description
- Added `conference_tournament_probs_20260314.py`, a standalone script that rebuilds Elo ratings from `Data/20101101-20260313.csv`, computes pairwise Elo win probabilities, and deterministically calculates title probabilities for each of the four teams in a conference semifinal bracket. 
- Script performs a sanity check against the today predictions file `Outputs/20260314 Game Predictions Based on Ratings through 20260313 with Spreads as of 20260314 at 0917.csv` and raises an error if a semifinal pairing is missing. 
- Writes results to `Outputs/2026 Conference Tournament Championship Probabilities 20260314.csv` with per-team Elo and tournament-win probabilities and prints a concise ranking summary to the terminal.

### Testing
- Ran `python conference_tournament_probs_20260314.py` successfully and confirmed the CSV was written to `Outputs/2026 Conference Tournament Championship Probabilities 20260314.csv`. 
- Verified per-conference probability totals sum to ~1.0 using a short CSV-check script, confirming consistency of the deterministic formulas. 
- Manual spot-check of printed summary confirmed expected output for each conference (Big Ten, SEC, American, A10, Ivy).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b573dede248329ad9e9853e9d9eb29)