### PR TITLE
Fix: Add tournament predictions visualization to GitHub Pages

### DIFF
--- a/.github/workflows/daily_predictions.yml
+++ b/.github/workflows/daily_predictions.yml
@@ -26,6 +26,7 @@ jobs:
           DATAWRAPPER_API_TOKEN: ${{ secrets.DATAWRAPPER_API_TOKEN }}
           DW_PREDICTIONS_CHART_ID: ${{ secrets.DW_PREDICTIONS_CHART_ID }}
           DW_RANKINGS_CHART_ID: ${{ secrets.DW_RANKINGS_CHART_ID }}
+          DW_PROBABILITIES_CHART_ID: ${{ secrets.DW_PROBABILITIES_CHART_ID }}
         run: python predictions.py -A
           
       - name: commit files

--- a/docs/index.html
+++ b/docs/index.html
@@ -184,6 +184,8 @@ Note: Teams with * or those written as abbreviations (e.g. BREC) are likely new 
         <p>Below are predictions for today's Men's college basketball games using an ELO rating methodology.</p>
         <p><strong>Interactive features:</strong> Click on any column header to sort by that column. Tables are fully responsive and work on mobile devices.</p>
         
+        <p>See also: <a href="https://www.datawrapper.de/_/9nuZY/">Tournament probabilities by round</a> (shareable chart).</p>
+        
         <p>Note: Teams with * or those written as abbreviations (e.g. BREC) are likely new to the model (i.e. they haven't played any/many D1 games) and predictions are more uncertain.</p>
         <p>Check out the full <a href="https://github.com/grdavis/college-basketball-elo">college-basketball-elo</a> repository on GitHub to see methodology and more.</p>
     </div>
@@ -191,6 +193,12 @@ Note: Teams with * or those written as abbreviations (e.g. BREC) are likely new 
     <div class="chart-container">
         <h2>Today's Game Predictions</h2>
         <iframe title="Daily Predictions" aria-label="Table" src="https://datawrapper.dwcdn.net/sXyuF/81/" 
+                scrolling="no" frameborder="0" style="width: 100%; min-height: 600px; border: none;"></iframe>
+    </div>
+
+    <div class="chart-container">
+        <h2>Tournament Probabilities by Round</h2>
+        <iframe title="Tournament Probabilities" aria-label="Table" src="https://datawrapper.dwcdn.net/9nuZY/1/" 
                 scrolling="no" frameborder="0" style="width: 100%; min-height: 600px; border: none;"></iframe>
     </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The tournament predictions visualization (Datawrapper chart 9nuZY) was not appearing on https://grdavis.github.io/college-basketball-elo/ due to two issues:

### Root cause

1. **Missing workflow env var**: The `daily_predictions.yml` workflow did not pass `DW_PROBABILITIES_CHART_ID` to the predictions script. The code in `predictions.py` reads this env var to build `probs_url`; when it's absent, `probs_url` is `None` and the tournament probabilities section is never included in the generated HTML.

2. **Current docs/index.html**: The live page was generated without the tournament embed, so it didn't show the visualization even though the chart exists at https://www.datawrapper.de/_/9nuZY/

### Changes

1. **`.github/workflows/daily_predictions.yml`**: Added `DW_PROBABILITIES_CHART_ID: ${{ secrets.DW_PROBABILITIES_CHART_ID }}` to the env block so future daily runs include the tournament probabilities embed.

2. **`docs/index.html`**: Added the tournament probabilities iframe and link so the visualization appears immediately after merge, without waiting for the next workflow run.

### Prerequisites

Ensure `DW_PROBABILITIES_CHART_ID` is set as a GitHub Secret (value: `9nuZY`) in the repository settings. If it's already configured, no further action is needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e2e0595-9bc4-4a77-b93d-54e7a0c77d49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e2e0595-9bc4-4a77-b93d-54e7a0c77d49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

